### PR TITLE
ci(deploy): unify container and router naming with environment prefix

### DIFF
--- a/.github/workflows/deploy-jobpt.yml
+++ b/.github/workflows/deploy-jobpt.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: 🚀 Deploy to PROD
         run: |
-          docker compose -p ${{ github.ref_name }} up -d --build
+          docker compose -p jobpt-${{ github.ref_name }} up -d --build
 
       - name: Cleanup old Docker images
         run: docker image prune -f
@@ -78,8 +78,8 @@ jobs:
 
       - name: 🚀 Deploy to DEV
         run: |
-          docker compose -p ${{ github.ref_name }} down --remove-orphans || true
-          docker compose -p ${{ github.ref_name }} up -d --build
+          docker compose -p jobpt-${{ github.ref_name }} down --remove-orphans || true
+          docker compose -p jobpt-${{ github.ref_name }} up -d --build
 
       - name: Cleanup old Docker images
         run: docker image prune -f

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,17 +25,17 @@ services:
       - traefik.docker.network=traefik
 
       # --- Traefik Router (Frontend) ---
-      - traefik.http.routers.jobpt-web.rule=Host(`${APP_HOST}`)
-      - traefik.http.routers.jobpt-web.entrypoints=websecure
-      - traefik.http.routers.jobpt-web.tls=true
-      - traefik.http.routers.jobpt-web.tls.certresolver=le
-      - traefik.http.services.jobpt-web.loadbalancer.server.port=3000
+      - traefik.http.routers.jobpt-${ENVIRONMENT}-web.rule=Host(`${APP_HOST}`)
+      - traefik.http.routers.jobpt-${ENVIRONMENT}-web.entrypoints=websecure
+      - traefik.http.routers.jobpt-${ENVIRONMENT}-web.tls=true
+      - traefik.http.routers.jobpt-${ENVIRONMENT}-web.tls.certresolver=le
+      - traefik.http.services.jobpt-${ENVIRONMENT}-web.loadbalancer.server.port=3000
 
       # --- HTTP → HTTPS 리다이렉트 ---
-      - traefik.http.routers.jobpt-web-http.rule=Host(`${APP_HOST}`)
-      - traefik.http.routers.jobpt-web-http.entrypoints=web
-      - traefik.http.routers.jobpt-web-http.middlewares=redirect-to-https@file
-      - traefik.http.routers.jobpt-web-http.service=jobpt-web
+      - traefik.http.routers.jobpt-${ENVIRONMENT}-web-http.rule=Host(`${APP_HOST}`)
+      - traefik.http.routers.jobpt-${ENVIRONMENT}-web-http.entrypoints=web
+      - traefik.http.routers.jobpt-${ENVIRONMENT}-web-http.middlewares=redirect-to-https@file
+      - traefik.http.routers.jobpt-${ENVIRONMENT}-web-http.service=jobpt-${ENVIRONMENT}-web
 
   backend:
     build:
@@ -66,28 +66,28 @@ services:
       - traefik.docker.network=traefik
 
       # --- Traefik Router (Backend /api) ---
-      - traefik.http.routers.jobpt-api.rule=Host(`${APP_HOST}`) && PathPrefix(`/api`)
-      - traefik.http.routers.jobpt-api.entrypoints=websecure
-      - traefik.http.routers.jobpt-api.tls=true
-      - traefik.http.routers.jobpt-api.tls.certresolver=le
-      - traefik.http.services.jobpt-api.loadbalancer.server.port=8000
+      - traefik.http.routers.jobpt-${ENVIRONMENT}-api.rule=Host(`${APP_HOST}`) && PathPrefix(`/api`)
+      - traefik.http.routers.jobpt-${ENVIRONMENT}-api.entrypoints=websecure
+      - traefik.http.routers.jobpt-${ENVIRONMENT}-api.tls=true
+      - traefik.http.routers.jobpt-${ENVIRONMENT}-api.tls.certresolver=le
+      - traefik.http.services.jobpt-${ENVIRONMENT}-api.loadbalancer.server.port=8000
 
       # FastAPI Docs router
-      - traefik.http.routers.jobpt-api-docs.rule=Host(`${APP_HOST}`) && (PathPrefix(`/docs`) || PathPrefix(`/redoc`) || PathPrefix(`/openapi.json`))
-      - traefik.http.routers.jobpt-api-docs.entrypoints=websecure
-      - traefik.http.routers.jobpt-api-docs.tls=true
-      - traefik.http.routers.jobpt-api-docs.tls.certresolver=le
-      - traefik.http.routers.jobpt-api-docs.service=jobpt-api
+      - traefik.http.routers.jobpt-${ENVIRONMENT}-api-docs.rule=Host(`${APP_HOST}`) && (PathPrefix(`/docs`) || PathPrefix(`/redoc`) || PathPrefix(`/openapi.json`))
+      - traefik.http.routers.jobpt-${ENVIRONMENT}-api-docs.entrypoints=websecure
+      - traefik.http.routers.jobpt-${ENVIRONMENT}-api-docs.tls=true
+      - traefik.http.routers.jobpt-${ENVIRONMENT}-api-docs.tls.certresolver=le
+      - traefik.http.routers.jobpt-${ENVIRONMENT}-api-docs.service=jobpt-${ENVIRONMENT}-api
 
       # /api prefix 제거 미들웨어 연결
-      - traefik.http.middlewares.jobpt-api-stripprefix.stripprefix.prefixes=/api
-      - traefik.http.routers.jobpt-api.middlewares=jobpt-api-stripprefix
+      - traefik.http.middlewares.jobpt-${ENVIRONMENT}-api-stripprefix.stripprefix.prefixes=/api
+      - traefik.http.routers.jobpt-${ENVIRONMENT}-api.middlewares=jobpt-${ENVIRONMENT}-api-stripprefix
 
       # HTTP → HTTPS 리다이렉트 (Backend)
-      - traefik.http.routers.jobpt-api-http.rule=Host(`${APP_HOST}`) && PathPrefix(`/api`)
-      - traefik.http.routers.jobpt-api-http.entrypoints=web
-      - traefik.http.routers.jobpt-api-http.middlewares=redirect-to-https@file
-      - traefik.http.routers.jobpt-api-http.service=jobpt-api
+      - traefik.http.routers.jobpt-${ENVIRONMENT}-api-http.rule=Host(`${APP_HOST}`) && PathPrefix(`/api`)
+      - traefik.http.routers.jobpt-${ENVIRONMENT}-api-http.entrypoints=web
+      - traefik.http.routers.jobpt-${ENVIRONMENT}-api-http.middlewares=redirect-to-https@file
+      - traefik.http.routers.jobpt-${ENVIRONMENT}-api-http.service=jobpt-${ENVIRONMENT}-api
 
 networks:
   traefik:


### PR DESCRIPTION
### 📝 PR 타입
<!-- 해당하는 타입에 대괄호 안에 x를 입력해주세요. -->
- [x] 리팩토링
- [x] 기타 (배포 파이프라인 구조 개선)

---

### 📜 설명
<!-- 무엇에 대한 PR인지 간결하게 설명해주세요. -->
환경별(`dev`/ `main`) 배포 시 컨테이너와 Traefik 라우터 이름이 충돌하는 문제를 해결했습니다.
`docker compose` 프로젝트 이름과 라우터 네임을 환경 접두사(prefix)로 통일하여 환경별로 완전히 분리된 배포 구조를 구성했습니다.


### 엮인 이슈
<!-- 이 PR이 닫을 이슈가 있다면, `Closes #이슈번호`를 사용해주세요. -->


---

### 🔨 작업 내용
<!-- 변경된 내용을 간략하게 요약하여 작성합니다. -->
- GitHub Actions 배포 워크플로우 수정
  - docker compose -p jobpt-${{ github.ref_name }} 형태로 컨테이너 프로젝트명 지정
- Docker Compose 파일 수정
  - Traefik 라우터/미들웨어 이름에 ${ENVIRONMENT} 접두사 추가
  - jobpt-dev, jobpt-main 형태로 환경별 서비스 식별 가능
- `.env` 기반 환경 변수 연동으로 dev/prod 자동 구분

### 📸 스크린샷
<!-- UI 변경이 포함된 경우, 스크린샷을 첨부를 권장합니다. -->

---

### 🧑‍💻 테스트 결과
<!-- 이 변경 사항을 어떻게 테스트했는지 설명합니다. -->


---

### 📅 체크리스트
- [x] 이해하기 어려운 부분에 주석을 추가했습니다.
- [x] 관련된 문서를 업데이트했습니다.