### PR TITLE
Backend 외부 노출 제거

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,8 +80,6 @@ services:
       MYSQL_USER: ${MYSQL_USER:-jobpt}
       MYSQL_PASSWORD: ${MYSQL_PASSWORD:-jobpt}
       MYSQL_DATABASE: ${MYSQL_DATABASE:-jobpt}
-    ports:
-      - "8000:8000"
     volumes:
       - jobpt_data:/app/data
       - jobpt_resumes:/app/uploaded_resumes


### PR DESCRIPTION
### 📝 PR 타입
<!-- 해당하는 타입에 대괄호 안에 x를 입력해주세요. -->
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 문서 업데이트
- [ ] 코드 스타일 업데이트 (포맷팅, 세미콜론 추가 등)
- [ ] 리팩토링
- [ ] 기타

---

### 📜 설명
<!-- 무엇에 대한 PR인지 간결하게 설명해주세요. -->
`docker-compose.yml`에서 Backend 서비스의 호스트 포트(8000) 노출을 제거했습니다.
외부 접근은 도메인 → Traefik → (Frontend/Backend 라우팅) 으로만 허용되도록 하여, Backend가 직접 외부에 노출되는 구성을 방지합니다.

### 엮인 이슈
<!--
여기에 이 PR로 닫을 이슈 번호를 적어주세요.

GitHub 자동 닫기 문법:
- Closes #123
- Closes #456   ← 여러 개는 이렇게 각각 따로 작성
-->
- Closes #

---

### 🔨 작업 내용
<!-- 변경된 내용을 간략하게 요약하여 작성합니다. -->
- Backend 서비스의 `ports: 8000:8000` 제거 (직접 외부 노출 차단)
- 외부 트래픽은 Traefik 라우팅을 통해서만 Backend에 도달하도록 구성 의도 정렬

### 📸 스크린샷
<!-- UI 변경이 포함된 경우, 스크린샷을 첨부를 권장합니다. -->

---

### 🧑‍💻 테스트 결과
<!-- 이 변경 사항을 어떻게 테스트했는지 설명합니다. -->

---

### 📅 체크리스트
- [x] 이해하기 어려운 부분에 주석을 추가했습니다.
- [x] 관련된 문서를 업데이트했습니다.